### PR TITLE
use portable `expr str : pattern` instead of `expr match ...`

### DIFF
--- a/frob3/configure
+++ b/frob3/configure
@@ -21,7 +21,7 @@ case $# in
   1)
     case $1 in
       --nitros9=* )
-        NITROS9=$(expr match "$1" '--nitros9=\(.*\)') ;;
+        NITROS9=$(expr "X$1" : 'X--nitros9=\(.*\)') ;;
         * ) fail Bad argument: $1 ;;
     esac ;;
 esac


### PR DESCRIPTION
with initial X as a guard, so initial dashes don't confuse it.

As I commented over here
  https://github.com/strickyak/coco-shelf/issues/3
I'll get rid of this soon and it'll be simpler to always use `../nitros9` on the shelf.  
